### PR TITLE
Add sample application and makefile for CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,10 @@ VENDORBIN = $(CURDIR)/vendor/bin
 PATH     := $(VENDORBIN):$(PATH)
 
 PROV_VERSION ?= $(shell git describe --tags 2>/dev/null ||  git rev-parse HEAD)
+
+# VERSION to be passed by jenkins for CI builds
+CI_VERSION ?= 
+
 PROV_REPO = quay.io/gravitational/provisioner
 TERRAFORM_VER ?= 0.10.8
 BUILDBOX_TAG ?= golang:1.9.0-stretch
@@ -20,6 +24,11 @@ build-provisioner: build
 .PHONY: publish-provisioner
 publish-provisioner:
 	docker push $(PROV_REPO):$(PROV_VERSION)
+
+# Publish docker image from CI, where jenkins is setting the image version
+.PHONY: publish-ci
+publish-ci:
+	docker push $(PROV_REPO):$(CI_VERSION)
 
 .PHONY: deps
 deps: vendor

--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,6 @@ PATH     := $(VENDORBIN):$(PATH)
 
 PROV_VERSION ?= $(shell git describe --tags 2>/dev/null ||  git rev-parse HEAD)
 
-# VERSION to be passed by jenkins for CI builds
-CI_VERSION ?= 
-
 PROV_REPO = quay.io/gravitational/provisioner
 TERRAFORM_VER ?= 0.10.8
 BUILDBOX_TAG ?= golang:1.9.0-stretch
@@ -24,11 +21,6 @@ build-provisioner: build
 .PHONY: publish-provisioner
 publish-provisioner:
 	docker push $(PROV_REPO):$(PROV_VERSION)
-
-# Publish docker image from CI, where jenkins is setting the image version
-.PHONY: publish-ci
-publish-ci:
-	docker push $(PROV_REPO):$(CI_VERSION)
 
 .PHONY: deps
 deps: vendor

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ VENDORBIN = $(CURDIR)/vendor/bin
 PATH     := $(VENDORBIN):$(PATH)
 
 PROV_VERSION ?= $(shell git describe --tags 2>/dev/null ||  git rev-parse HEAD)
-
 PROV_REPO = quay.io/gravitational/provisioner
 TERRAFORM_VER ?= 0.10.8
 BUILDBOX_TAG ?= golang:1.9.0-stretch

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -18,6 +18,11 @@ TAG ?=
 TELE_FLAGS :=
 CWD := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 
+TELE ?= $(shell command -v tele;)
+ifndef TELE
+$(error "tele is not available, please install using this docs http://gravitational.com/docs/quickstart/#getting-the-tools")
+endif
+
 
 .PHONY: ci
 ci: tele-login
@@ -25,20 +30,20 @@ ci: tele-login
 	mkdir -p $(TMP)/resources/
 	cp $(CWD)/resources/* $(TMP)/resources/
 	find $(TMP)/resources/ -type f -name '*.yaml' -exec sed -i 's|XXX_PROVISIONER_VERSION_XXX|$(TAG)|' {} \;
-	tele $(TELE_FLAGS) build \
+	$(TELE) $(TELE_FLAGS) build \
         	--skip-version-check \
 		--output="$(TMP)/installer.tar" \
 		--version="1.0.0-$(TAG)" \
 		--overwrite \
 		--repository="https://$(OPS_URL)" \
 		"$(TMP)/resources/app.yaml"
-	tele $(TELE_FLAGS) push --force "$(TMP)/installer.tar"
+	$(TELE) $(TELE_FLAGS) push --force "$(TMP)/installer.tar"
 	rm -r $(TMP)
 
 
 .PHONY: tele-login
 tele-login: check-env
-	tele login --ops=${OPS_URL} --key=${OPS_KEY}
+	$(TELE) login --ops=${OPS_URL} --key=${OPS_KEY}
 
 .PHONY: check-env
 check-env:

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -1,0 +1,47 @@
+# This Makefile is used by CI/CD builds.
+#
+# Prerequisites:
+#     - Docker 1.9.1 or newer
+#     - You must be a part of 'docker' group to use Docker without sudo
+#
+
+.DEFAULT_GOAL := ci
+
+OPS_URL :=
+OPS_KEY :=
+TAG :=
+TELE_FLAGS :=
+CWD := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+APP_VERSION ?= $(shell git -C $(CWD) describe --tags)
+
+
+.PHONY: ci
+ci: tele-login
+	$(eval TMP := $(shell mktemp -d))
+	mkdir -p $(TMP)/resources/
+	cp $(CWD)/resources/* $(TMP)/resources/
+	find $(TMP)/resources/ -type f -name '*.yaml' -exec sed -i 's|XXX_PROVISIONER_VERSION_XXX|$(TAG)|' {} \;
+	tele $(TELE_FLAGS) build \
+        --skip-version-check \
+		--output="$(TMP)/installer.tar" \
+		--version="$(APP_VERSION)" \
+		--overwrite "$(TMP)/resources/app.yaml" --repository="https://$(OPS_URL)"
+	tele $(TELE_FLAGS) push --force "$(TMP)/installer.tar"
+	rm -r $(TMP)
+
+
+.PHONY: tele-login
+tele-login: check-env
+	tele login --ops=${OPS_URL} --key=${OPS_KEY}
+
+.PHONY: check-env
+check-env:
+ifndef OPS_URL
+	$(error OPS_URL is undefined)
+endif
+ifndef OPS_KEY
+	$(error OPS_KEY is undefined)
+endif
+ifndef TAG
+	$(error TAG is undefined)
+endif

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -2,14 +2,19 @@
 #
 # Prerequisites:
 #     - Docker 1.9.1 or newer
-#     - You must be a part of 'docker' group to use Docker without sudo
+#     - User must be a part of 'docker' group to use Docker without sudo
 #
 
 .DEFAULT_GOAL := ci
 
-OPS_URL :=
-OPS_KEY :=
-TAG :=
+# URL of OPS server to build off of and upload app to
+OPS_URL ?=
+# OPS Center token to login
+OPS_KEY ?=
+# The tag on quay.io of the provisioning container to use
+TAG ?=
+
+
 TELE_FLAGS :=
 CWD := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 
@@ -17,14 +22,13 @@ CWD := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 .PHONY: ci
 ci: tele-login
 	$(eval TMP := $(shell mktemp -d))
-	mkdir -p $(TMP)/resources/
-	cp $(CWD)/resources/* $(TMP)/resources/
-	find $(TMP)/resources/ -type f -name '*.yaml' -exec sed -i 's|XXX_PROVISIONER_VERSION_XXX|$(TAG)|' {} \;
 	tele $(TELE_FLAGS) build \
-        --skip-version-check \
+        	--skip-version-check \
 		--output="$(TMP)/installer.tar" \
-		--version="0.0.0-$(TAG)" \
-		--overwrite "$(TMP)/resources/app.yaml" --repository="https://$(OPS_URL)"
+		--version="1.0.0-$(TAG)" \
+		--overwrite "$(CWD)/resources/app.yaml" \
+		--repository="https://$(OPS_URL)" \
+		--set-image=quay.io/gravitational/provisioner:$(TAG)
 	tele $(TELE_FLAGS) push --force "$(TMP)/installer.tar"
 	rm -r $(TMP)
 

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -12,7 +12,6 @@ OPS_KEY :=
 TAG :=
 TELE_FLAGS :=
 CWD := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
-APP_VERSION ?= $(shell git -C $(CWD) describe --tags)
 
 
 .PHONY: ci
@@ -24,7 +23,7 @@ ci: tele-login
 	tele $(TELE_FLAGS) build \
         --skip-version-check \
 		--output="$(TMP)/installer.tar" \
-		--version="$(APP_VERSION)" \
+		--version="0.0.0-$(TAG)" \
 		--overwrite "$(TMP)/resources/app.yaml" --repository="https://$(OPS_URL)"
 	tele $(TELE_FLAGS) push --force "$(TMP)/installer.tar"
 	rm -r $(TMP)

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -22,13 +22,17 @@ CWD := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 .PHONY: ci
 ci: tele-login
 	$(eval TMP := $(shell mktemp -d))
+	mkdir -p $(TMP)/resources/
+	cp $(CWD)/resources/* $(TMP)/resources/
+	find $(TMP)/resources/ -type f -name '*.yaml' -exec sed -i 's|XXX_PROVISIONER_VERSION_XXX|$(TAG)|' {} \;
 	tele $(TELE_FLAGS) build \
         	--skip-version-check \
 		--output="$(TMP)/installer.tar" \
 		--version="1.0.0-$(TAG)" \
-		--overwrite "$(CWD)/resources/app.yaml" \
+		--overwrite \
 		--repository="https://$(OPS_URL)" \
-		--set-image=quay.io/gravitational/provisioner:$(TAG)
+		--set-image=quay.io/gravitational/provisioner:$(TAG) \
+		"$(TMP)/resources/app.yaml"
 	tele $(TELE_FLAGS) push --force "$(TMP)/installer.tar"
 	rm -r $(TMP)
 

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -31,7 +31,6 @@ ci: tele-login
 		--version="1.0.0-$(TAG)" \
 		--overwrite \
 		--repository="https://$(OPS_URL)" \
-		--set-image=quay.io/gravitational/provisioner:$(TAG) \
 		"$(TMP)/resources/app.yaml"
 	tele $(TELE_FLAGS) push --force "$(TMP)/installer.tar"
 	rm -r $(TMP)

--- a/build.assets/README.md
+++ b/build.assets/README.md
@@ -1,1 +1,12 @@
-### TODO(knisbet) create readme for CI builds
+### Build Assets
+This directory is used by Jenkins to build a sample gravity application for CI/CD testing of changes to the provisioner.
+
+To execute manually run:
+```
+make OPS_URL=<ops_url> OPS_KEY=<ops_key> TAG=<docker_tag>
+```
+
+Where
+- OPS_URL: URL of ops center to use for the sample application
+- OPS_KEY: token to access the ops center
+- TAG: is a tag of the provisioning container available at https://quay.io/repository/gravitational/provisioner?tab=tags

--- a/build.assets/README.md
+++ b/build.assets/README.md
@@ -1,5 +1,5 @@
 ### Build Assets
-This directory is used by Jenkins to build a sample gravity application for CI/CD testing of changes to the provisioner.
+This directory is used by Jenkins to build a sample telekube application for CI/CD testing of changes to the provisioner.
 
 To execute manually run:
 ```

--- a/build.assets/README.md
+++ b/build.assets/README.md
@@ -1,0 +1,1 @@
+### TODO(knisbet) create readme for CI builds

--- a/build.assets/resources/app.yaml
+++ b/build.assets/resources/app.yaml
@@ -1,0 +1,101 @@
+apiVersion: bundle.gravitational.io/v2
+kind: Bundle
+metadata:
+  name: ci
+  description: |
+    This is a sample gravitational app used for CI
+  resourceVersion: 0.2.0-alpha
+  namespace: default
+
+license:
+  enabled: false
+
+endpoints:
+  - name: "Gravity Cluster"
+    description: "Admin control panel"
+    selector:
+      app: gravity-site
+    protocol: https
+
+providers:
+  azure:
+    disabled: true
+  aws:
+    regions:
+      - us-east-1
+      - us-east-2
+      - us-west-1
+      - us-west-2
+      - eu-central-1
+      - eu-west-1
+      - eu-west-2
+      - ap-northeast-1
+      - ap-northeast-2
+      - ap-south-1
+      - ap-southeast-1
+      - ap-southeast-2
+      - ca-central-1
+      - sa-east-1
+
+installer:
+  flavors:
+    prompt: "Select a flavor"
+    default: "one"
+    items:
+      - name: "one"
+        description: "1 node"
+        nodes:
+          - profile: node
+            count: 1
+
+nodeProfiles:
+  - name: node
+    description: "Telekube Node"
+    labels:
+      role: node
+    requirements:
+      cpu:
+        min: 1
+      ram:
+        min: "2GB"
+      os:
+        - name: centos
+          versions: ["7"]
+      volumes:
+        - path: /var/lib/gravity
+          capacity: "10GB"
+          filesystems: ["xfs", "ext4"]
+    providers:
+      aws:
+        instanceTypes:
+          - c4.large
+          - c4.xlarge
+          - c4.2xlarge
+          - c4.4xlarge
+          - c4.8xlarge
+          - m4.large
+          - m4.xlarge
+          - m4.2xlarge
+          - m4.4xlarge
+          - m4.10xlarge
+          - m4.16xlarge
+          - t2.medium
+          - t2.large
+          - t2.xlarge
+          - t2.2xlarge
+
+systemOptions:
+  docker:
+    storageDriver: overlay2
+  runtime:
+    version: 5.0.0-alpha.3
+
+hooks:
+  clusterProvision:
+    job: file://clusterProvision.yaml
+  clusterDeprovision:
+    job: file://clusterDeprovision.yaml
+  nodesProvision:
+    job: file://nodesProvision.yaml
+  nodesDeprovision:
+    job: file://nodesDeprovision.yaml

--- a/build.assets/resources/app.yaml
+++ b/build.assets/resources/app.yaml
@@ -53,6 +53,7 @@ nodeProfiles:
     description: "Telekube Node"
     labels:
       role: node
+      node-role.kubernetes.io/master: "true"
     requirements:
       cpu:
         min: 1

--- a/build.assets/resources/clusterDeprovision.yaml
+++ b/build.assets/resources/clusterDeprovision.yaml
@@ -12,7 +12,7 @@ spec:
       - name: devdocker-registrykey
       containers:
       - name: provision
-        image: quay.io/gravitational/provisioner
+        image: quay.io/gravitational/provisioner:XXX_PROVISIONER_VERSION_XXX
         imagePullPolicy: Always
         args: ['cluster-deprovision']
         volumeMounts:

--- a/build.assets/resources/clusterDeprovision.yaml
+++ b/build.assets/resources/clusterDeprovision.yaml
@@ -12,7 +12,7 @@ spec:
       - name: devdocker-registrykey
       containers:
       - name: provision
-        image: quay.io/gravitational/provisioner:XXX_PROVISIONER_VERSION_XXX
+        image: quay.io/gravitational/provisioner
         imagePullPolicy: Always
         args: ['cluster-deprovision']
         volumeMounts:

--- a/build.assets/resources/clusterDeprovision.yaml
+++ b/build.assets/resources/clusterDeprovision.yaml
@@ -1,0 +1,23 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: deprovision
+  namespace: default
+spec:
+  activeDeadlineSeconds: 240
+  template:
+    spec:
+      restartPolicy: OnFailure
+      imagePullSecrets:
+      - name: devdocker-registrykey
+      containers:
+      - name: provision
+        image: quay.io/gravitational/provisioner:XXX_PROVISIONER_VERSION_XXX
+        imagePullPolicy: Always
+        args: ['cluster-deprovision']
+        volumeMounts:
+        - mountPath: /mnt/state
+          name: state-volume
+      volumes:
+      - name: state-volume
+        emptyDir: {}

--- a/build.assets/resources/clusterProvision.yaml
+++ b/build.assets/resources/clusterProvision.yaml
@@ -1,0 +1,21 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: provision
+  namespace: default
+spec:
+  activeDeadlineSeconds: 240
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+      - name: provision
+        image: quay.io/gravitational/provisioner:XXX_PROVISIONER_VERSION_XXX
+        imagePullPolicy: Always
+        args: ['cluster-provision']
+        volumeMounts:
+        - mountPath: /mnt/state
+          name: state-volume
+      volumes:
+      - name: state-volume
+        emptyDir: {}

--- a/build.assets/resources/clusterProvision.yaml
+++ b/build.assets/resources/clusterProvision.yaml
@@ -10,7 +10,7 @@ spec:
       restartPolicy: OnFailure
       containers:
       - name: provision
-        image: quay.io/gravitational/provisioner
+        image: quay.io/gravitational/provisioner:XXX_PROVISIONER_VERSION_XXX
         imagePullPolicy: Always
         args: ['cluster-provision']
         volumeMounts:

--- a/build.assets/resources/clusterProvision.yaml
+++ b/build.assets/resources/clusterProvision.yaml
@@ -10,7 +10,7 @@ spec:
       restartPolicy: OnFailure
       containers:
       - name: provision
-        image: quay.io/gravitational/provisioner:XXX_PROVISIONER_VERSION_XXX
+        image: quay.io/gravitational/provisioner
         imagePullPolicy: Always
         args: ['cluster-provision']
         volumeMounts:

--- a/build.assets/resources/nodesDeprovision.yaml
+++ b/build.assets/resources/nodesDeprovision.yaml
@@ -12,7 +12,7 @@ spec:
       - name: devdocker-registrykey
       containers:
       - name: provision
-        image: quay.io/gravitational/provisioner
+        image: quay.io/gravitational/provisioner:XXX_PROVISIONER_VERSION_XXX
         imagePullPolicy: Always
         args: ['nodes-deprovision']
         volumeMounts:

--- a/build.assets/resources/nodesDeprovision.yaml
+++ b/build.assets/resources/nodesDeprovision.yaml
@@ -12,7 +12,7 @@ spec:
       - name: devdocker-registrykey
       containers:
       - name: provision
-        image: quay.io/gravitational/provisioner:XXX_PROVISIONER_VERSION_XXX
+        image: quay.io/gravitational/provisioner
         imagePullPolicy: Always
         args: ['nodes-deprovision']
         volumeMounts:

--- a/build.assets/resources/nodesDeprovision.yaml
+++ b/build.assets/resources/nodesDeprovision.yaml
@@ -1,0 +1,23 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: nodes-deprovision
+  namespace: default
+spec:
+  activeDeadlineSeconds: 240
+  template:
+    spec:
+      restartPolicy: OnFailure
+      imagePullSecrets:
+      - name: devdocker-registrykey
+      containers:
+      - name: provision
+        image: quay.io/gravitational/provisioner:XXX_PROVISIONER_VERSION_XXX
+        imagePullPolicy: Always
+        args: ['nodes-deprovision']
+        volumeMounts:
+        - mountPath: /mnt/state
+          name: state-volume
+      volumes:
+      - name: state-volume
+        emptyDir: {}

--- a/build.assets/resources/nodesProvision.yaml
+++ b/build.assets/resources/nodesProvision.yaml
@@ -12,7 +12,7 @@ spec:
       - name: devdocker-registrykey
       containers:
       - name: provision
-        image: quay.io/gravitational/provisioner
+        image: quay.io/gravitational/provisioner:XXX_PROVISIONER_VERSION_XXX
         imagePullPolicy: Always
         args: ['nodes-provision']
         volumeMounts:

--- a/build.assets/resources/nodesProvision.yaml
+++ b/build.assets/resources/nodesProvision.yaml
@@ -12,7 +12,7 @@ spec:
       - name: devdocker-registrykey
       containers:
       - name: provision
-        image: quay.io/gravitational/provisioner:XXX_PROVISIONER_VERSION_XXX
+        image: quay.io/gravitational/provisioner
         imagePullPolicy: Always
         args: ['nodes-provision']
         volumeMounts:

--- a/build.assets/resources/nodesProvision.yaml
+++ b/build.assets/resources/nodesProvision.yaml
@@ -1,0 +1,23 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: nodes-provision
+  namespace: default
+spec:
+  activeDeadlineSeconds: 240
+  template:
+    spec:
+      restartPolicy: OnFailure
+      imagePullSecrets:
+      - name: devdocker-registrykey
+      containers:
+      - name: provision
+        image: quay.io/gravitational/provisioner:XXX_PROVISIONER_VERSION_XXX
+        imagePullPolicy: Always
+        args: ['nodes-provision']
+        volumeMounts:
+        - mountPath: /mnt/state
+          name: state-volume
+      volumes:
+      - name: state-volume
+        emptyDir: {}


### PR DESCRIPTION
Adds a sample gravity application for the provisioner to use during CI builds.

I attempted to be consistent with the directory structure of gravity, where build.assets is being used for Jenkins CI/CD, however, this doesn't build the provisioning container, right now it only has a sample application that uses the provisioner.

Also, right now I'm publishing to quay.io/gravitational/provisioner but I'm not sure if it's a great idea to spam it with a new tag on each build by jenkins.