### PR TITLE
Several small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Below are required variables for all tasks:
 * AWS_ACCESS_KEY_ID: aws access key id
 * AWS_SECRET_ACCESS_KEY: aws secret key
 * TELEKUBE_CLUSTER_NAME: telekube cluster. We will store generated
-  script in a bucket in form of **terraform-cluster-state-$(TELEKUBE_CLUSTER_NAME)**
+  script in a bucket in form of **provisioner-terraform-state/$(TELEKUBE_CLUSTER_NAME)**
 * AWS_KEY_NAME: SSH key for ec2 instance. The SSH key needs to be
   pre-created in AWS
 * TELEKUBE_OPS_TOKEN: an agent token of telekube cluster

--- a/build.assets/resources/app.yaml
+++ b/build.assets/resources/app.yaml
@@ -53,7 +53,10 @@ nodeProfiles:
     description: "Telekube Node"
     labels:
       role: node
-      node-role.kubernetes.io/master: "true"
+#	TODO(knisbet) it appears that setting node-role.kubernetes.io to master, removes the node from the load balancer
+#	which prevents gravity join from being able to reach the cluster
+#	https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/service/service_controller.go#L614
+#      node-role.kubernetes.io/master: "true"
     requirements:
       cpu:
         min: 1

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -177,7 +177,7 @@ sync-files:
 		--region=$(AWS_REGION) \
 		--cluster-bucket=$(BUCKET_NAME) \
 		--target=/mnt/state/cluster/input \
-		--prefix=cluster
+		--prefix=$(TELEKUBE_CLUSTER_NAME)/cluster
 
 
 .PHONY: terraform-init

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -37,7 +37,7 @@ AWS_INSTANCE_PRIVATE_IP ?=
 # AWS instance private DNS name of the instance to delet
 AWS_INSTANCE_PRIVATE_DNS ?=
 # S3 bucket name to keep the state
-BUCKET_NAME ?= terraform-cluster-state-$(TELEKUBE_CLUSTER_NAME)
+BUCKET_NAME ?= provisioner-terraform-state
 # directory with this makefile
 CWD := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 
@@ -166,7 +166,7 @@ init-cluster:
 		--vpc-id=$(AWS_VPC_ID) \
 		--cluster-bucket=$(BUCKET_NAME) \
 		--template=$(CWD)/terraform/templates/vars.tf.template \
-		--key=cluster/vars.tf
+		--key=$(TELEKUBE_CLUSTER_NAME)/cluster/vars.tf
 
 
 # sync-files syncs files from S3 to input directory

--- a/scripts/terraform/node-user-data.tpl
+++ b/scripts/terraform/node-user-data.tpl
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -x
 
+# Set some curl options so that temporary failures get retried
+# More info: https://ec.haxx.se/usingcurl-timeouts.html
+CURL_OPTS="--retry 100 --retry-delay 0 --connect-timeout 10 --max-time 300"
+
 umount /dev/xvdb
 mkfs.ext4 /dev/xvdb
 sed -i.bak '/xvdb/d' /etc/fstab
@@ -14,15 +18,15 @@ export SUDO_UID=1000
 export SUDO_GID=1000
 
 # install python to get access to SSM
-curl --retry 100 --retry-delay 0 --connect-timeout 10 --max-time 300 -O https://bootstrap.pypa.io/get-pip.py
+curl ${CURL_OPTS} -O https://bootstrap.pypa.io/get-pip.py
 python2.7 get-pip.py
 pip install awscli
-EC2_AVAIL_ZONE=`curl --retry 100 --retry-delay 0 --connect-timeout 10 --max-time 300 -s http://169.254.169.254/latest/meta-data/placement/availability-zone`
+EC2_AVAIL_ZONE=`curl ${CURL_OPTS} -s http://169.254.169.254/latest/meta-data/placement/availability-zone`
 EC2_REGION="`echo \"$EC2_AVAIL_ZONE\" | sed -e 's:\([0-9][0-9]*\)[a-z]*\$:\\1:'`"
 TELEKUBE_SERVICE=`aws ssm get-parameter --name /telekube/${cluster_name}/service --region $EC2_REGION --output text 2>&1 | awk '{ print $4 }'`
 
 # Download gravity of the right version directly from the cluster
-curl --retry 100 --retry-delay 0 --connect-timeout 10 --max-time 300 -k -o /tmp/gravity $${TELEKUBE_SERVICE}/telekube/gravity
+curl ${CURL_OPTS} -k -o /tmp/gravity $${TELEKUBE_SERVICE}/telekube/gravity
 chmod +x /tmp/gravity
 
 # In AWS mode gravity will discover the data from AWS SSM and join the cluster

--- a/scripts/terraform/node-user-data.tpl
+++ b/scripts/terraform/node-user-data.tpl
@@ -18,15 +18,15 @@ export SUDO_UID=1000
 export SUDO_GID=1000
 
 # install python to get access to SSM
-curl ${CURL_OPTS} -O https://bootstrap.pypa.io/get-pip.py
+curl $${CURL_OPTS} -O https://bootstrap.pypa.io/get-pip.py
 python2.7 get-pip.py
 pip install awscli
-EC2_AVAIL_ZONE=`curl ${CURL_OPTS} -s http://169.254.169.254/latest/meta-data/placement/availability-zone`
+EC2_AVAIL_ZONE=`curl $${CURL_OPTS} -s http://169.254.169.254/latest/meta-data/placement/availability-zone`
 EC2_REGION="`echo \"$EC2_AVAIL_ZONE\" | sed -e 's:\([0-9][0-9]*\)[a-z]*\$:\\1:'`"
 TELEKUBE_SERVICE=`aws ssm get-parameter --name /telekube/${cluster_name}/service --region $EC2_REGION --output text 2>&1 | awk '{ print $4 }'`
 
 # Download gravity of the right version directly from the cluster
-curl ${CURL_OPTS} -k -o /tmp/gravity $${TELEKUBE_SERVICE}/telekube/gravity
+curl $${CURL_OPTS} -k -o /tmp/gravity $${TELEKUBE_SERVICE}/telekube/gravity
 chmod +x /tmp/gravity
 
 # In AWS mode gravity will discover the data from AWS SSM and join the cluster

--- a/scripts/terraform/node-user-data.tpl
+++ b/scripts/terraform/node-user-data.tpl
@@ -14,15 +14,15 @@ export SUDO_UID=1000
 export SUDO_GID=1000
 
 # install python to get access to SSM
-curl -O https://bootstrap.pypa.io/get-pip.py
+curl --retry 100 --retry-delay 0 --connect-timeout 10 --max-time 300 -O https://bootstrap.pypa.io/get-pip.py
 python2.7 get-pip.py
 pip install awscli
-EC2_AVAIL_ZONE=`curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone`
+EC2_AVAIL_ZONE=`curl --retry 100 --retry-delay 0 --connect-timeout 10 --max-time 300 -s http://169.254.169.254/latest/meta-data/placement/availability-zone`
 EC2_REGION="`echo \"$EC2_AVAIL_ZONE\" | sed -e 's:\([0-9][0-9]*\)[a-z]*\$:\\1:'`"
 TELEKUBE_SERVICE=`aws ssm get-parameter --name /telekube/${cluster_name}/service --region $EC2_REGION --output text 2>&1 | awk '{ print $4 }'`
 
 # Download gravity of the right version directly from the cluster
-curl -k -o /tmp/gravity $${TELEKUBE_SERVICE}/telekube/gravity
+curl --retry 100 --retry-delay 0 --connect-timeout 10 --max-time 300 -k -o /tmp/gravity $${TELEKUBE_SERVICE}/telekube/gravity
 chmod +x /tmp/gravity
 
 # In AWS mode gravity will discover the data from AWS SSM and join the cluster

--- a/scripts/terraform/user-data.tpl
+++ b/scripts/terraform/user-data.tpl
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -xeuo pipefail
 
+# Set some curl options so that temporary failures get retried
+# More info: https://ec.haxx.se/usingcurl-timeouts.html
+CURL_OPTS="--retry 100 --retry-delay 0 --connect-timeout 10 --max-time 300"
+
 # mount all required volumes
 umount /dev/xvdb || true
 mkfs.ext4 /dev/xvdb
@@ -22,4 +26,4 @@ export SUDO_UID=1000
 export SUDO_GID=1000
 
 # This calls opscenter to start the provision k8s job
-curl --retry 100 --retry-delay 0 --connect-timeout 10 --max-time 300 --tlsv1.2 --insecure '${ops_url}/${ops_token}/node?provisioner=aws_terraform&bg=true' | bash
+curl ${CURL_OPTS} --tlsv1.2 --insecure '${ops_url}/${ops_token}/node?provisioner=aws_terraform&bg=true' | bash

--- a/scripts/terraform/user-data.tpl
+++ b/scripts/terraform/user-data.tpl
@@ -26,4 +26,4 @@ export SUDO_UID=1000
 export SUDO_GID=1000
 
 # This calls opscenter to start the provision k8s job
-curl ${CURL_OPTS} --tlsv1.2 --insecure '${ops_url}/${ops_token}/node?provisioner=aws_terraform&bg=true' | bash
+curl $${CURL_OPTS} --tlsv1.2 --insecure '${ops_url}/${ops_token}/node?provisioner=aws_terraform&bg=true' | bash

--- a/scripts/terraform/user-data.tpl
+++ b/scripts/terraform/user-data.tpl
@@ -22,4 +22,4 @@ export SUDO_UID=1000
 export SUDO_GID=1000
 
 # This calls opscenter to start the provision k8s job
-curl --tlsv1.2 --insecure '${ops_url}/${ops_token}/node?provisioner=aws_terraform&bg=true' | bash
+curl --retry 100 --retry-delay 0 --connect-timeout 10 --max-time 300 --tlsv1.2 --insecure '${ops_url}/${ops_token}/node?provisioner=aws_terraform&bg=true' | bash


### PR DESCRIPTION
Sorry, got a few small fixes that I've been testing grouped together:

- node-role.kubernetes.io/master: "true"
It turns out, that setting master, will make the node ineligible for load balancing, which is the only nodes deployed are masters, don't allow the gravity-service to be reachable for workers to join the cluster from the ASG. Temporarily I've just commented out the flag, but we'll likely need a longer term solution.

- Terraform bucket(s)
Previously, each cluster would create it's own s3 bucket, which is kind of spammy, as pointed out by @klizhentas. So I've merged the structure to use a single bucket.

- Curl retries
Some of my cluster installations failed apparently due to a failure in the curl command to reach the ops center. So I went through, and set some retry and timeout options on each curl usage to ***hopefully*** make it a bit more reliable if a temporary failure occurs.