### PR TITLE
Set timeouts on AWS calls where available

### DIFF
--- a/build.assets/resources/clusterDeprovision.yaml
+++ b/build.assets/resources/clusterDeprovision.yaml
@@ -4,7 +4,7 @@ metadata:
   name: deprovision
   namespace: default
 spec:
-  activeDeadlineSeconds: 600
+  activeDeadlineSeconds: 900
   template:
     spec:
       restartPolicy: OnFailure

--- a/command.go
+++ b/command.go
@@ -159,9 +159,6 @@ func (c *Command) Run(args []string) error {
 	var err error
 	invokedCommad, err := c.App.Parse(args)
 
-	// temporarily set the log level to debug
-	log.SetLevel(log.DebugLevel)
-
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/command.go
+++ b/command.go
@@ -159,6 +159,9 @@ func (c *Command) Run(args []string) error {
 	var err error
 	invokedCommad, err := c.App.Parse(args)
 
+	// temporarily set the log level to debug
+	log.SetLevel(log.DebugLevel)
+
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/command.go
+++ b/command.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/gravitational/trace"
+	log "github.com/sirupsen/logrus"
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 
@@ -171,6 +172,10 @@ func (c *Command) Run(args []string) error {
 		err = c.findInstance.perform(*c.cfg)
 	case c.removeS3Key.FullCommand():
 		err = c.removeS3Key.perform(*c.cfg)
+	}
+
+	if err != nil {
+		log.Error("failed to run command: ", trace.DebugReport(err))
 	}
 
 	return err

--- a/loader.go
+++ b/loader.go
@@ -51,7 +51,8 @@ type LoaderConfig struct {
 // NewLoader initializes Loader from a LoadConfig and related AWS Service
 func NewLoader(config LoaderConfig) (*Loader, error) {
 	sess, err := session.NewSession(&aws.Config{
-		Region: aws.String(config.Region),
+		Region:   aws.String(config.Region),
+		LogLevel: aws.LogLevel(aws.LogDebug),
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/loader.go
+++ b/loader.go
@@ -24,8 +24,8 @@ import (
 )
 
 const (
-	// AwsOperationTimeout is the amount of time to wait for calls to AWS to complete
-	AwsOperationTimeout = 30 * time.Second
+	// AWSOperationTimeout is the amount of time to wait for calls to AWS to complete
+	AWSOperationTimeout = 30 * time.Second
 )
 
 // Loader governs process of inspecting VPC and generating TerraForm template
@@ -354,7 +354,7 @@ func (l *Loader) loadVPC() (*ec2.Vpc, error) {
 
 // UpsertBucket upserts bucket if it does not exist
 func (l *Loader) UpsertBucket() error {
-	ctx, cancel := context.WithTimeout(context.Background(), AwsOperationTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), AWSOperationTimeout)
 	defer cancel()
 
 	input := &s3.CreateBucketInput{
@@ -417,7 +417,7 @@ func (l *Loader) PutKey(bucketName, bucketKey string, out io.ReadSeeker, content
 }
 
 func (l *Loader) initVars(bucketKey string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), AwsOperationTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), AWSOperationTimeout)
 	defer cancel()
 
 	err := l.UpsertBucket()
@@ -448,7 +448,7 @@ func (l *Loader) initVars(bucketKey string) error {
 
 func (l *Loader) sync(paths []string, targetDir string) error {
 	log.Debug("starting sync operation")
-	ctx, cancel := context.WithTimeout(context.Background(), AwsOperationTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), AWSOperationTimeout)
 	defer cancel()
 
 	log.WithField("targetDir", targetDir).Debug("creating target directory")
@@ -490,7 +490,7 @@ func (l *Loader) sync(paths []string, targetDir string) error {
 }
 
 func (l *Loader) rm(key string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), AwsOperationTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), AWSOperationTimeout)
 	defer cancel()
 
 	params := &s3.DeleteObjectInput{

--- a/loader.go
+++ b/loader.go
@@ -447,18 +447,25 @@ func (l *Loader) initVars(bucketKey string) error {
 }
 
 func (l *Loader) sync(paths []string, targetDir string) error {
+	log.Debug("starting sync operation")
 	ctx, cancel := context.WithTimeout(context.Background(), AwsOperationTimeout)
 	defer cancel()
 
+	log.WithField("targetDir", targetDir).Debug("creating target directory")
 	err := os.MkdirAll(targetDir, 0755)
 	if err != nil {
 		return trace.ConvertSystemError(err)
 	}
+
 	for _, path := range paths {
 		params := &s3.ListObjectsInput{
 			Bucket: aws.String(l.ClusterBucket),
 			Prefix: aws.String(path),
 		}
+		log.WithFields(log.Fields{
+			"Bucket": params.Bucket,
+			"Prefix": params.Prefix,
+		}).Debug("listing objects")
 		resp, err := l.ListObjectsWithContext(ctx, params)
 		if err != nil {
 			return trace.Wrap(err)
@@ -477,6 +484,8 @@ func (l *Loader) sync(paths []string, targetDir string) error {
 		}
 
 	}
+
+	log.Debug("sync complete")
 	return nil
 }
 

--- a/loader.go
+++ b/loader.go
@@ -51,8 +51,7 @@ type LoaderConfig struct {
 // NewLoader initializes Loader from a LoadConfig and related AWS Service
 func NewLoader(config LoaderConfig) (*Loader, error) {
 	sess, err := session.NewSession(&aws.Config{
-		Region:   aws.String(config.Region),
-		LogLevel: aws.LogLevel(aws.LogDebug),
+		Region: aws.String(config.Region),
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/loader.go
+++ b/loader.go
@@ -23,6 +23,11 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+const (
+	// AwsOperationTimeout is the amount of time to wait for calls to AWS to complete
+	AwsOperationTimeout = 30 * time.Second
+)
+
 // Loader governs process of inspecting VPC and generating TerraForm template
 // We support 2 modes of loading
 //   * load with an existing VPC: in this case, we will re-use nat gateway,
@@ -349,7 +354,7 @@ func (l *Loader) loadVPC() (*ec2.Vpc, error) {
 
 // UpsertBucket upserts bucket if it does not exist
 func (l *Loader) UpsertBucket() error {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), AwsOperationTimeout)
 	defer cancel()
 
 	input := &s3.CreateBucketInput{
@@ -412,7 +417,7 @@ func (l *Loader) PutKey(bucketName, bucketKey string, out io.ReadSeeker, content
 }
 
 func (l *Loader) initVars(bucketKey string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), AwsOperationTimeout)
 	defer cancel()
 
 	err := l.UpsertBucket()
@@ -442,7 +447,7 @@ func (l *Loader) initVars(bucketKey string) error {
 }
 
 func (l *Loader) sync(paths []string, targetDir string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), AwsOperationTimeout)
 	defer cancel()
 
 	err := os.MkdirAll(targetDir, 0755)
@@ -476,7 +481,7 @@ func (l *Loader) sync(paths []string, targetDir string) error {
 }
 
 func (l *Loader) rm(key string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), AwsOperationTimeout)
 	defer cancel()
 
 	params := &s3.DeleteObjectInput{


### PR DESCRIPTION
Recently I've encounter a few failures with de-provisioning a cluster, that appear to be hangs in the s3 synchronization of the terraform configuration.

I'm not really sure why this occurs, but the aws utils support timeouts using context, so this change just throws in some timeouts on the S3 calls where available. 